### PR TITLE
Fixing bug when msg-frame_id unequal global rviz-frame

### DIFF
--- a/kindr_rviz_plugins/src/VectorAtPositionDisplay.cpp
+++ b/kindr_rviz_plugins/src/VectorAtPositionDisplay.cpp
@@ -161,7 +161,9 @@ void VectorAtPositionDisplay::updateVectorAtPosition() {
       return;
     }
   }
-  arrowPosition += Ogre::Vector3(current_vector_at_position_->position.x, current_vector_at_position_->position.y, current_vector_at_position_->position.z);
+  Ogre::Matrix3 rotMat;
+  arrowOrientation.ToRotationMatrix(rotMat);
+  arrowPosition +=  rotMat*Ogre::Vector3(current_vector_at_position_->position.x, current_vector_at_position_->position.y, current_vector_at_position_->position.z);
 
   // We are keeping a circular buffer of visual pointers. This gets
   // the next one, or creates and stores it if the buffer is not full


### PR DESCRIPTION
Inserted transform of position contents of messages into the global rviz-frame, before they are added to the position of the local frame's origin. This fixes a bug, namely that vector messages with nonzero position contents are placed incorrectly unless the global rviz-frame is set to the frame of the message header.
@pfankhauser This solves my problem