### PR TITLE
Changed font from Arial (removed in RViz 1.12.12) to Liberation Sans.

### DIFF
--- a/kindr_rviz_plugins/src/VectorAtPositionVisual.cpp
+++ b/kindr_rviz_plugins/src/VectorAtPositionVisual.cpp
@@ -185,7 +185,7 @@ void VectorAtPositionVisual::updateText()
 {
   // add description text if available
   const std::string textString = showText_? name_ : "";
-  text_.reset(new rviz::MovableText(textString, "Arial", 0.1));
+  text_.reset(new rviz::MovableText(textString, "Liberation Sans", 0.1));
   text_->setTextAlignment(rviz::MovableText::H_CENTER, rviz::MovableText::V_BELOW);
   scene_node_text_->attachObject(text_.get());
 }


### PR DESCRIPTION
Solved issue that made RViz throw an OGRE exception and crash whenever a VectorAtPosition was displayed. This was due to the substitution of Arial by Liberation Sans from Rviz 1.12.12 on (Issue #1141, https://github.com/ros-visualization/rviz/pull/1141).