### PR TITLE
Fix ros2 compile definition -DROS2_BUILD

### DIFF
--- a/kindr_ros/CMakeLists.txt
+++ b/kindr_ros/CMakeLists.txt
@@ -95,6 +95,7 @@ endforeach()
 ###########
 
 add_library(${PROJECT_NAME} INTERFACE)
+target_compile_definitions(${PROJECT_NAME} INTERFACE -DROS2_BUILD)
 target_include_directories(${PROJECT_NAME}
   INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
The compile definition to select the ROS2_BUILD specific code was missing.